### PR TITLE
Changed code to load AT only for preview

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -102,5 +102,7 @@ function buildTwitterLinks() {
 if (!window.location.hostname.includes('localhost')) {
   
   embedCustomLibraries();
-  loadAT();
+  if (!(window.location.href.indexOf('/canvas/') > -1)) {
+    loadAT();
+  }
 }


### PR DESCRIPTION
Added a check to call loadAT() only if page is not under authoring. This is done so that targeting doesn't happen in authoring.